### PR TITLE
Handle the comment context

### DIFF
--- a/py-smart-operator.el
+++ b/py-smart-operator.el
@@ -39,16 +39,16 @@
 
 (defvar py-smart-operator-operators
   '(
-   ;; ( char in-string in-paren in-global)
-	("+" py-smart-operator-do-nothing py-smart-operator-do-wrap py-smart-operator-do-wrap)
-	("-" py-smart-operator-do-nothing py-smart-operator-do-wrap py-smart-operator-do-wrap)
-	("/" py-smart-operator-do-nothing py-smart-operator-do-wrap py-smart-operator-do-wrap)
-    ("*" py-smart-operator-do-nothing py-smart-operator-do-wrap py-smart-operator-do-wrap)
-	("=" py-smart-operator-do-nothing py-smart-operator-do-nothing py-smart-operator-do-wrap)
-	("," py-smart-operator-do-nothing py-smart-operator-do-space-after py-smart-operator-do-space-after)
-	(":" py-smart-operator-do-nothing py-smart-operator-do-space-after py-smart-operator-do-nothing)
-	("<" py-smart-operator-do-nothing py-smart-operator-do-nothing py-smart-operator-do-wrap)
-	(">" py-smart-operator-do-nothing py-smart-operator-do-nothing py-smart-operator-do-wrap)
+    ;; ( char in-comment in-string in-paren in-global)
+    ("+" py-smart-operator-do-nothing py-smart-operator-do-nothing py-smart-operator-do-wrap py-smart-operator-do-wrap)
+    ("-" py-smart-operator-do-nothing py-smart-operator-do-nothing py-smart-operator-do-wrap py-smart-operator-do-wrap)
+    ("/" py-smart-operator-do-nothing py-smart-operator-do-nothing py-smart-operator-do-wrap py-smart-operator-do-wrap)
+    ("*" py-smart-operator-do-nothing py-smart-operator-do-nothing py-smart-operator-do-wrap py-smart-operator-do-wrap)
+    ("=" py-smart-operator-do-nothing py-smart-operator-do-nothing py-smart-operator-do-nothing py-smart-operator-do-wrap)
+    ("," py-smart-operator-do-nothing py-smart-operator-do-nothing py-smart-operator-do-space-after py-smart-operator-do-space-after)
+    (":" py-smart-operator-do-nothing py-smart-operator-do-nothing py-smart-operator-do-space-after py-smart-operator-do-nothing)
+    ("<" py-smart-operator-do-nothing py-smart-operator-do-nothing py-smart-operator-do-nothing py-smart-operator-do-wrap)
+    (">" py-smart-operator-do-nothing py-smart-operator-do-nothing py-smart-operator-do-nothing py-smart-operator-do-wrap)
     )
   "Registered operators")
 
@@ -81,7 +81,7 @@
       (progn
         (delete-char to-delete)
         (insert to-insert)))
-   )))
+    )))
 
 (defun py-smart-operator-do-wrap (prev-symbols arg)
   "Decide what to do inside of paren"
@@ -105,13 +105,17 @@
   "Insert required operator by looking to configuration in operators var"
   (let ((prev (buffer-substring-no-properties (- (point) 2) (point)))
         (arg (car option))
-        (do-when-string (nth 1 option))
-        (do-when-paren (nth 2 option))
-        (do-when-global (nth 3 option)))
+        (context (python-syntax-context-type))
+        (do-when-comment (nth 1 option))
+        (do-when-string (nth 2 option))
+        (do-when-paren (nth 3 option))
+        (do-when-global (nth 4 option)))
     (cond
-     ((eq (python-syntax-context-type) 'string)
+     ((eq context 'comment)
+      (py-smart-operator-insert (funcall do-when-comment prev arg)))
+     ((eq context 'string)
       (py-smart-operator-insert (funcall do-when-string prev arg)))
-     ((eq (python-syntax-context-type) 'paren)
+     ((eq context 'paren)
       (py-smart-operator-insert (funcall do-when-paren prev arg)))
      (t (py-smart-operator-insert (funcall do-when-global prev arg))))
     ))


### PR DESCRIPTION
When using this mode I noticed how I also often find myself annoyed by the way py-smart-operator also works in comments (e.g., when writing something like `#!/usr/bin/env python`), and there was no way to fix it.

This PR adds a generic way to handle the comment context with `py-smart-do-nothing` as a default behavior.